### PR TITLE
Add buttons to cycle through videos for a specific movie

### DIFF
--- a/src/components/Modal/Modal.css
+++ b/src/components/Modal/Modal.css
@@ -119,3 +119,42 @@ p {
     color: black;
     font-weight: 500%;
 }
+
+.loading {
+    height: 100%;
+    width: 100%;
+    margin: 0;
+    padding-top: 80px;
+    color: white;
+    background-color: rgb(147, 49, 28, .8);
+    text-align: center;
+    font-size: 3em;
+}
+
+.video-box {
+    display: flex;
+    position: absolute;
+    align-items: flex-end;
+    height: 40%;
+    width: 42%;
+    right: 29%;
+    bottom: -40%;
+}
+
+.movie-trailer {
+    height: 100%;
+    width: 80%;
+}
+
+.previous-btn-container,
+.next-btn-container {
+    height: 10%;
+    width: 10%;
+    margin-bottom: 5px;
+}
+
+.previous-video,
+.next-video {
+    height: 100%;
+    width: 100%;
+}

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -4,6 +4,10 @@ import dayjs from 'dayjs'
 import { NavLink } from 'react-router-dom'
 import { getAllData } from '../../api-calls';
 
+let movie;
+let videos;
+let index = 0
+
 class SingleMovie extends Component {
   constructor() {
     super();
@@ -16,17 +20,31 @@ class SingleMovie extends Component {
   componentDidMount = () => {
     getAllData(`/movies/${this.props.id}`).then(data => {
       this.setState({ movie: [data[0].movie] })
+      movie = data[0].movie
     })
     getAllData(`/movies/${this.props.id}/videos`).then(data => {
-      this.setState({ video: [data[0].videos] })
+      this.setState({ video: data[0].videos[0] })
+      videos = data[0].videos
     })
   }
 
+  nextVideo = () => {
+    if (index < videos.length - 1) {
+    index++
+    this.setState({ video: videos[index] })
+    }
+  }
+
+  previousVideo = () => {
+    if (index > 0) {
+      index--
+      this.setState({ video: videos[index] })
+    }
+  }
+
   render = () => {
-    let movie = this.state.movie[0]
-    let video = this.state.video[0]
-    if (movie === undefined || video === undefined) {
-      return 'Loading...'
+    if (movie === undefined || videos === undefined) {
+      return <p className='loading'>Loading...</p>
     } else {
       return (
       <section className='movie-info'> 
@@ -46,15 +64,21 @@ class SingleMovie extends Component {
         <p className='modal-rating'><i><b>Rating: </b>{(movie.average_rating).toFixed(1)}</i></p>
         {movie.tagline.length > 0 && <p className='tagline'><i>"{movie.tagline}"</i></p>}
         <img className='modal-back-drop' id={movie.id} src={movie.backdrop_path} alt='poster'/>
-        <iframe
-          width="853"
-          height="480"
-          src={`https://www.youtube.com/embed/${video[0].key}`}
-          frameBorder="0"
-          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-          allowFullScreen
-          title="Embedded youtube"
-        />
+        {videos.length > 0 && <section className='video-box'>
+          <div className='previous-btn-container'>
+            {videos.length > 1 && index > 0 && <button className='previous-video' onClick={this.previousVideo} >Previous</button>}
+          </div>
+          <iframe className='movie-trailer'
+            src={`https://www.youtube.com/embed/${this.state.video.key}`}
+            frameBorder="0"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+            allowFullScreen
+            title="Embedded youtube"
+          />
+          <div className="next-btn-container">
+            {videos.length > 1 && index < videos.length - 1 && <button className='next-video' onClick={this.nextVideo} >Next</button>}
+          </div>
+        </section>}
       </section>
       )
     }


### PR DESCRIPTION
What's this PR do?
- Added the videos the the movie details page
- Add buttons to cycle through the videos (for those that have multiple videos)
- The buttons for previous/next will appear/disappear when you reach the beginning/end of the list of videos
- The video will only render if the movie actually does have a video connected to it (found a few that do not have videos and this was throwing an error and breaking the page)
- Positioned the video area at the bottom of the movie details screen
- Buttons still need some styling but everything should be functioning
- Every once in a while, the video does not load properly, but fixes itself after a page refresh or a click of the previous/next buttons.  Not sure why this is happening, seems like maybe an issue with YouTube?
- Lots of conditional rendering within the Modal/SingleMovie.  It looks a little messy but everything is working as far as I can tell

- [x] New feature (adds functionality)
- [x] I tested my changes in the browser
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new bugs
